### PR TITLE
Issue: Invalid or corrupted pad block

### DIFF
--- a/lib/src/crypto_dart.dart
+++ b/lib/src/crypto_dart.dart
@@ -70,6 +70,7 @@ class CryptoDart {
         key: key,
         hasher: hasher,
         keyEncoding: keyEncoding,
+        blockLength: blockLength,
         keySize: keySize);
   }
 

--- a/lib/src/pbkdf2.dart
+++ b/lib/src/pbkdf2.dart
@@ -9,10 +9,11 @@ Uint8List PBKDF2(
     int keySize = 4,
     required Uint8List salt,
     String keyEncoding = 'utf8',
+    required int blockLength,
     required String key}) {
   final digest = Digest(hasher);
 
-  final pbkdf2 = PBKDF2KeyDerivator(HMac(digest, keySize * digest.digestSize));
+  final pbkdf2 = PBKDF2KeyDerivator(HMac(digest, blockLength));
 
   pbkdf2.init(Pbkdf2Parameters(salt, iterations, keySize * 8));
 


### PR DESCRIPTION
This issue occurred while decrypting ciphers made in other platforms (Java). Due to an incorrect calculation of blockSize, inputPad was set to the wrong value. Hence, relying on the user-given `blockLength` is necessary to address correct encryption/decryption.